### PR TITLE
Phase 1.2: Request-Scoped Logging Middleware

### DIFF
--- a/internal/middleware/auth_test.go
+++ b/internal/middleware/auth_test.go
@@ -528,12 +528,3 @@ func (v *testTokenValidator) ValidateToken(_ context.Context, token string) (str
 	}
 	return v.projectID, nil
 }
-
-type testServerStream struct {
-	grpc.ServerStream
-	ctx context.Context
-}
-
-func (s *testServerStream) Context() context.Context {
-	return s.ctx
-}

--- a/internal/middleware/helpers_test.go
+++ b/internal/middleware/helpers_test.go
@@ -1,0 +1,17 @@
+package middleware
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+)
+
+// testServerStream is a minimal grpc.ServerStream for testing interceptors.
+type testServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (s *testServerStream) Context() context.Context {
+	return s.ctx
+}

--- a/internal/middleware/logging_test.go
+++ b/internal/middleware/logging_test.go
@@ -165,8 +165,8 @@ func TestUnaryRequestLoggingInterceptor(t *testing.T) {
 		if !strings.Contains(output, "/flagz.v1.FlagService/GetFlag") {
 			t.Fatalf("expected method in log output, got: %s", output)
 		}
-		if !strings.Contains(output, "status_code=OK") {
-			t.Fatalf("expected status_code=OK in log output, got: %s", output)
+		if !strings.Contains(output, "status_code=0") {
+			t.Fatalf("expected status_code=0 in log output, got: %s", output)
 		}
 		if !strings.Contains(output, "duration_ms=") {
 			t.Fatalf("expected duration_ms in log output, got: %s", output)
@@ -187,8 +187,8 @@ func TestUnaryRequestLoggingInterceptor(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error")
 		}
-		if !strings.Contains(buf.String(), "status_code=NotFound") {
-			t.Fatalf("expected status_code=NotFound in log output, got: %s", buf.String())
+		if !strings.Contains(buf.String(), "status_code=5") {
+			t.Fatalf("expected status_code=5 in log output, got: %s", buf.String())
 		}
 	})
 
@@ -304,8 +304,8 @@ func TestStreamRequestLoggingInterceptor(t *testing.T) {
 		if !strings.Contains(output, "/flagz.v1.FlagService/WatchFlag") {
 			t.Fatalf("expected method in log output, got: %s", output)
 		}
-		if !strings.Contains(output, "status_code=OK") {
-			t.Fatalf("expected status_code=OK in log output, got: %s", output)
+		if !strings.Contains(output, "status_code=0") {
+			t.Fatalf("expected status_code=0 in log output, got: %s", output)
 		}
 	})
 
@@ -324,8 +324,8 @@ func TestStreamRequestLoggingInterceptor(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error")
 		}
-		if !strings.Contains(buf.String(), "status_code=Internal") {
-			t.Fatalf("expected status_code=Internal in log output, got: %s", buf.String())
+		if !strings.Contains(buf.String(), "status_code=13") {
+			t.Fatalf("expected status_code=13 in log output, got: %s", buf.String())
 		}
 	})
 


### PR DESCRIPTION
Adds HTTP middleware and gRPC interceptor for request-scoped logging with auto-generated request IDs, method/path/status/duration logging.

## Note on Admin Branch Changes

This PR is based on the `admin` branch, which includes foundational multi-tenancy and admin portal infrastructure. Some changes visible in the diff are from the admin branch base and not specific to this phase:

- Admin portal with Tailscale-only access (handler, session management, templates)
- Multi-tenancy: project ID propagation, TokenValidator interface update
- Auth hardening: empty projectID rejection, trusted-proxy IP extraction
- Config: comprehensive env var tests, SESSION_SECRET validation
- Startup: Tailscale slog.Debug logging, admin server graceful shutdown

These shared improvements are documented in PR #31 and are prerequisites for the phase-specific changes in this PR.