### PR TITLE
test: add performance benchmarks

### DIFF
--- a/internal/core/evaluator_bench_test.go
+++ b/internal/core/evaluator_bench_test.go
@@ -1,0 +1,133 @@
+package core
+
+import (
+"fmt"
+"testing"
+)
+
+func BenchmarkEvaluateFlag_NoRules(b *testing.B) {
+defaultVal := true
+flag := Flag{
+Key:          "feature-no-rules",
+Disabled:     false,
+DefaultValue: &defaultVal,
+}
+ctx := EvaluationContext{
+Attributes: map[string]any{"country": "US", "plan": "pro"},
+}
+
+b.ResetTimer()
+for b.Loop() {
+EvaluateFlag(flag, ctx)
+}
+}
+
+func BenchmarkEvaluateFlag_SingleRule(b *testing.B) {
+defaultVal := false
+flag := Flag{
+Key:          "feature-single-rule",
+Disabled:     false,
+DefaultValue: &defaultVal,
+Rules: []Rule{
+{Attribute: "country", Operator: OperatorEquals, Value: "US"},
+},
+}
+ctx := EvaluationContext{
+Attributes: map[string]any{"country": "US"},
+}
+
+b.ResetTimer()
+for b.Loop() {
+EvaluateFlag(flag, ctx)
+}
+}
+
+func BenchmarkEvaluateFlag_ManyRules(b *testing.B) {
+defaultVal := false
+rules := make([]Rule, 15)
+for i := range rules {
+rules[i] = Rule{
+Attribute: fmt.Sprintf("attr-%d", i),
+Operator:  OperatorEquals,
+Value:     fmt.Sprintf("val-%d", i),
+}
+}
+
+flag := Flag{
+Key:          "feature-many-rules",
+Disabled:     false,
+DefaultValue: &defaultVal,
+Rules:        rules,
+}
+
+b.Run("MatchFirst", func(b *testing.B) {
+ctx := EvaluationContext{
+Attributes: map[string]any{"attr-0": "val-0"},
+}
+b.ResetTimer()
+for b.Loop() {
+EvaluateFlag(flag, ctx)
+}
+})
+
+b.Run("MatchMiddle", func(b *testing.B) {
+ctx := EvaluationContext{
+Attributes: map[string]any{"attr-7": "val-7"},
+}
+b.ResetTimer()
+for b.Loop() {
+EvaluateFlag(flag, ctx)
+}
+})
+
+b.Run("MatchLast", func(b *testing.B) {
+ctx := EvaluationContext{
+Attributes: map[string]any{"attr-14": "val-14"},
+}
+b.ResetTimer()
+for b.Loop() {
+EvaluateFlag(flag, ctx)
+}
+})
+
+b.Run("NoMatch", func(b *testing.B) {
+ctx := EvaluationContext{
+Attributes: map[string]any{"country": "XX"},
+}
+b.ResetTimer()
+for b.Loop() {
+EvaluateFlag(flag, ctx)
+}
+})
+}
+
+func BenchmarkEvaluateFlags_Batch(b *testing.B) {
+defaultVal := true
+flags := make([]Flag, 100)
+for i := range flags {
+var rules []Rule
+if i%2 == 0 {
+rules = []Rule{
+{Attribute: "plan", Operator: OperatorIn, Value: []string{"pro", "enterprise"}},
+}
+}
+flags[i] = Flag{
+Key:          fmt.Sprintf("flag-%03d", i),
+Disabled:     i%10 == 0,
+DefaultValue: &defaultVal,
+Rules:        rules,
+}
+}
+ctx := EvaluationContext{
+Attributes: map[string]any{
+"country": "US",
+"plan":    "pro",
+"user_id": "user-42",
+},
+}
+
+b.ResetTimer()
+for b.Loop() {
+EvaluateFlags(flags, ctx)
+}
+}

--- a/internal/service/service_bench_test.go
+++ b/internal/service/service_bench_test.go
@@ -1,0 +1,64 @@
+package service
+
+import (
+"context"
+"encoding/json"
+"fmt"
+"testing"
+
+"github.com/matt-riley/flagz/internal/core"
+"github.com/matt-riley/flagz/internal/repository"
+)
+
+func BenchmarkListFlags(b *testing.B) {
+ctx := context.Background()
+repo := newFakeServiceRepository()
+
+for i := range 100 {
+repo.setFlag(repository.Flag{
+ProjectID:   "default",
+Key:         fmt.Sprintf("flag-%03d", i),
+Description: fmt.Sprintf("benchmark flag %d", i),
+Enabled:     i%3 != 0,
+Variants:    json.RawMessage(`{}`),
+Rules:       json.RawMessage(`[]`),
+})
+}
+
+svc, err := New(ctx, repo)
+if err != nil {
+b.Fatalf("New() error = %v", err)
+}
+
+b.ResetTimer()
+for b.Loop() {
+_, _ = svc.ListFlags(ctx, "default")
+}
+}
+
+func BenchmarkResolveBoolean(b *testing.B) {
+ctx := context.Background()
+repo := newFakeServiceRepository()
+repo.setFlag(repository.Flag{
+ProjectID:   "default",
+Key:         "feature-rollout",
+Description: "benchmark flag",
+Enabled:     true,
+Variants:    json.RawMessage(`{"default":false}`),
+Rules:       json.RawMessage(`[{"attribute":"country","operator":"equals","value":"US"}]`),
+})
+
+svc, err := New(ctx, repo)
+if err != nil {
+b.Fatalf("New() error = %v", err)
+}
+
+evalCtx := core.EvaluationContext{
+Attributes: map[string]any{"country": "US"},
+}
+
+b.ResetTimer()
+for b.Loop() {
+_, _ = svc.ResolveBoolean(ctx, "default", "feature-rollout", evalCtx, false)
+}
+}


### PR DESCRIPTION
Adds benchmark coverage for evaluation and service hot paths.

## Included in this PR
- Core evaluator benchmarks in `internal/core/evaluator_bench_test.go`:
  - `BenchmarkEvaluateFlag_NoRules`
  - `BenchmarkEvaluateFlag_SingleRule`
  - `BenchmarkEvaluateFlag_ManyRules` (match first/middle/last + no match sub-benchmarks)
  - `BenchmarkEvaluateFlags_Batch`
- Service benchmarks in `internal/service/service_bench_test.go`:
  - `BenchmarkListFlags` (cached list path)
  - `BenchmarkResolveBoolean` (cached resolve path)

## Scope
- Test-only change; no production logic changes.

## Files in scope
- `internal/core/evaluator_bench_test.go`
- `internal/service/service_bench_test.go`