### PR TITLE
chore: bump matt-riley-ci workflow refs to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    uses: matt-riley/matt-riley-ci/.github/workflows/go-ci.yml@0d1d8e7a149a53fcaaca6e128f62e0e3d8fdf293 # v2
+    uses: matt-riley/matt-riley-ci/.github/workflows/go-ci.yml@bcaf4ae43edf7d26421741424b82c842c83e55ce # v2
     with:
       go-version-file: go.mod
       run-race: true
@@ -15,7 +15,7 @@ jobs:
       concurrency-suffix: test
 
   test-go-client:
-    uses: matt-riley/matt-riley-ci/.github/workflows/go-ci.yml@0d1d8e7a149a53fcaaca6e128f62e0e3d8fdf293 # v2
+    uses: matt-riley/matt-riley-ci/.github/workflows/go-ci.yml@bcaf4ae43edf7d26421741424b82c842c83e55ce # v2
     with:
       go-version-file: go.mod
       working-directory: clients/go

--- a/.github/workflows/clients-typescript-ci.yml
+++ b/.github/workflows/clients-typescript-ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-and-test:
-    uses: matt-riley/matt-riley-ci/.github/workflows/node-ci.yml@0d1d8e7a149a53fcaaca6e128f62e0e3d8fdf293 # v2
+    uses: matt-riley/matt-riley-ci/.github/workflows/node-ci.yml@bcaf4ae43edf7d26421741424b82c842c83e55ce # v2
     with:
       node-version: "24"
       package-manager: npm

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   docker-publish:
-    uses: matt-riley/matt-riley-ci/.github/workflows/docker-ghcr-publish.yml@92dae3a7b997354d5b579165f9e0cbe3463905c2
+    uses: matt-riley/matt-riley-ci/.github/workflows/docker-ghcr-publish.yml@bcaf4ae43edf7d26421741424b82c842c83e55ce
     with:
       tag-name: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event_name == 'repository_dispatch' && github.event.client_payload.tag_name || github.event.inputs.tag_name || '' }}
     secrets:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   release-please:
-    uses: matt-riley/matt-riley-ci/.github/workflows/release-please.yml@92dae3a7b997354d5b579165f9e0cbe3463905c2
+    uses: matt-riley/matt-riley-ci/.github/workflows/release-please.yml@bcaf4ae43edf7d26421741424b82c842c83e55ce
     with:
       config-file: release-please-config.json
       manifest-file: .release-please-manifest.json


### PR DESCRIPTION
Bumps all matt-riley-ci reusable workflow references to the latest commit.

Old SHAs replaced: 0d1d8e7a149a53fcaaca6e128f62e0e3d8fdf293, 92dae3a7b997354d5b579165f9e0cbe3463905c2
New SHA: bcaf4ae43edf7d26421741424b82c842c83e55ce