### PR TITLE
fix: port to Universal CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,17 +7,16 @@ on:
 
 jobs:
   test:
-    uses: matt-riley/matt-riley-ci/.github/workflows/go-ci.yml@bcaf4ae43edf7d26421741424b82c842c83e55ce # v2
+    uses: matt-riley/matt-riley-ci/.github/workflows/ci.yml@bcaf4ae43edf7d26421741424b82c842c83e55ce # v2
     with:
-      go-version-file: go.mod
-      run-race: true
-      run-vet: true
+      install: true
+      test: true
       concurrency-suffix: test
 
   test-go-client:
-    uses: matt-riley/matt-riley-ci/.github/workflows/go-ci.yml@bcaf4ae43edf7d26421741424b82c842c83e55ce # v2
+    uses: matt-riley/matt-riley-ci/.github/workflows/ci.yml@bcaf4ae43edf7d26421741424b82c842c83e55ce # v2
     with:
-      go-version-file: go.mod
+      install: true
+      test: true
       working-directory: clients/go
-      run-vet: true
       concurrency-suffix: test-go-client

--- a/.github/workflows/clients-typescript-ci.yml
+++ b/.github/workflows/clients-typescript-ci.yml
@@ -7,15 +7,13 @@ on:
 
 jobs:
   build-and-test:
-    uses: matt-riley/matt-riley-ci/.github/workflows/node-ci.yml@bcaf4ae43edf7d26421741424b82c842c83e55ce # v2
+    uses: matt-riley/matt-riley-ci/.github/workflows/ci.yml@bcaf4ae43edf7d26421741424b82c842c83e55ce # v2
     with:
-      node-version: "24"
-      package-manager: npm
+      install: true
       working-directory: clients/typescript
-      cache-dependency-path: clients/typescript/package-lock.json
-      run-lint: false
-      run-test: true
-      run-build: true
+      lint: false
+      test: true
+      build: true
 
   verify-proto-sync:
     runs-on: ubuntu-latest

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,14 @@
+[tools]
+go = "1.26.4"
+
+[tasks.test]
+description = "Run Go tests"
+run = "go test ./..."
+
+[tasks.vet]
+description = "Run go vet"
+run = "go vet ./..."
+
+[tasks.build]
+description = "Build"
+run = "go build ./..."


### PR DESCRIPTION
Ports CI from deprecated `go-ci.yml` / `node-ci.yml` (which no longer exist in matt-riley-ci) to the Universal `ci.yml`.

- Added mise.toml with Go tasks
- Ported ci.yml to Universal CI
- Ported clients-typescript-ci.yml