### PR TITLE
chore: bump matt-riley-ci refs to 071c2c2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,14 @@ on:
 
 jobs:
   test:
-    uses: matt-riley/matt-riley-ci/.github/workflows/ci.yml@bcaf4ae43edf7d26421741424b82c842c83e55ce # v2
+    uses: matt-riley/matt-riley-ci/.github/workflows/ci.yml@071c2c2 # v2
     with:
       install: true
       test: true
       concurrency-suffix: test
 
   test-go-client:
-    uses: matt-riley/matt-riley-ci/.github/workflows/ci.yml@bcaf4ae43edf7d26421741424b82c842c83e55ce # v2
+    uses: matt-riley/matt-riley-ci/.github/workflows/ci.yml@071c2c2 # v2
     with:
       install: true
       test: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   docker-publish:
-    uses: matt-riley/matt-riley-ci/.github/workflows/docker-ghcr-publish.yml@bcaf4ae43edf7d26421741424b82c842c83e55ce
+    uses: matt-riley/matt-riley-ci/.github/workflows/docker-ghcr-publish.yml@071c2c2
     with:
       tag-name: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event_name == 'repository_dispatch' && github.event.client_payload.tag_name || github.event.inputs.tag_name || '' }}
     secrets:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -12,7 +12,7 @@ permissions:
 
 jobs:
   release-please:
-    uses: matt-riley/matt-riley-ci/.github/workflows/release-please.yml@bcaf4ae43edf7d26421741424b82c842c83e55ce
+    uses: matt-riley/matt-riley-ci/.github/workflows/release-please.yml@071c2c2
     with:
       config-file: release-please-config.json
       manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

Updated three workflow files to reference matt-riley-ci at SHA 071c2c2:

| Workflow file | Ref updated | Old SHA | New SHA |
|---|---|---|---|
| `.github/workflows/ci.yml` | 2 refs | bcaf4ae | 071c2c2 |
| `.github/workflows/docker-publish.yml` | docker-ghcr-publish | bcaf4ae | 071c2c2 |
| `.github/workflows/release-please.yml` | release-please | bcaf4ae | 071c2c2 |

No other changes.